### PR TITLE
fix(events): at least kde plasma sends events in a different order

### DIFF
--- a/content.js
+++ b/content.js
@@ -314,12 +314,23 @@
           }
         });
 
+        // INFO:
+        // This fixes an issue with at least KDE Plasma where key events
+        // are inconsistently fired on keydown vs keyup
+        // and ensures that the closeTabSwitcher action is triggered even after blur
+        input.addEventListener("keyup", (e) => {
+          if (keyMatches(e, configCache.keys.closeTabSwitcher)) {
+            escListener(e);
+            return;
+          }
+        });
+
         input.addEventListener("keydown", (e) => {
           const items = list.querySelectorAll("li");
           const numItems = items.length;
 
           if (keyMatches(e, configCache.keys.closeTabSwitcher)) {
-            escListener(e);
+            // handled by keyup to ensure it triggers before any potential input changes
             return;
           }
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Zen Browser Tab Switcher",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Tab switcher for Zen Browser with a minimal omnibar overlay",
   "permissions": [
     "storage",


### PR DESCRIPTION
Keydown events never reach the input field, when you hit escape on KDE Plasma, because it blurs the input first.

On Gnome Wayland, this works as expected.

This should make it work on both platforms.

Also add some tooling for ease of dx.