### PR TITLE
fix(events): try to stop bubbling input event on close

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,3 +1,5 @@
+import { Logger } from "./utils.js";
+
 /* Listen for the command */
 browser.commands.onCommand.addListener((command) => {
   if (command === "show-zen-browner-tab-switcher-omnibar") {
@@ -8,17 +10,16 @@ browser.commands.onCommand.addListener((command) => {
         if (tabs[0] && Number.isInteger(tabs[0].id) && tabs[0].id >= 0) {
           browser.tabs
             .sendMessage(tabs[0].id, { type: "showOmnibar" })
-            .then(() => {
-            })
+            .then(() => {})
             .catch((error) => {
-              console.error("Error sending showOmnibar message:", error);
+              Logger.error("Error sending showOmnibar message:", error);
             });
         } else {
-          console.error("No valid active tab found");
+          Logger.error("No valid active tab found");
         }
       })
       .catch((error) => {
-        console.error("Error querying tabs:", error);
+        Logger.error("Error querying tabs:", error);
       });
   }
 });
@@ -40,14 +41,14 @@ browser.runtime.onMessage.addListener((message, _, sendResponse) => {
         );
       })
       .catch((error) => {
-        console.error("Error querying tabs:", error);
+        Logger.error("Error querying tabs:", error);
         sendResponse({ error: error.message });
       });
     return true; /* Keep the message channel open for async response */
   } else if (message.type === "switchTab") {
     const tabId = message.tabId;
     if (!Number.isInteger(tabId) || tabId < 0) {
-      console.error("Invalid tabId:", tabId);
+      Logger.error("Invalid tabId:", tabId);
       sendResponse({ error: "Invalid tabId" });
       return true;
     }
@@ -55,7 +56,7 @@ browser.runtime.onMessage.addListener((message, _, sendResponse) => {
       .get(tabId)
       .then((tab) => {
         if (!tab || !Number.isInteger(tab.windowId)) {
-          console.error("Tab not found or invalid windowId for tabId:", tabId);
+          Logger.error("Tab not found or invalid windowId for tabId:", tabId);
           sendResponse({ error: "Tab or window not found" });
           return;
         }
@@ -68,33 +69,34 @@ browser.runtime.onMessage.addListener((message, _, sendResponse) => {
                 sendResponse({ success: true });
               })
               .catch((error) => {
-                console.error("Error activating tab:", error);
+                Logger.error("Error activating tab:", error);
                 sendResponse({ error: error.message });
               });
           })
           .catch((error) => {
-            console.error("Error focusing window:", error);
+            Logger.error("Error focusing window:", error);
             sendResponse({ error: error.message });
           });
       })
       .catch((error) => {
-        console.error("Error getting tab:", error);
+        Logger.error("Error getting tab:", error);
         sendResponse({ error: error.message });
       });
     return true; /* Keep the message channel open for async response */
   } else if (message.type === "closeTab") {
     const tabId = message.tabId;
     if (!Number.isInteger(tabId) || tabId < 0) {
-      console.error("Invalid tabId for closing:", tabId);
+      Logger.error("Invalid tabId for closing:", tabId);
       sendResponse({ error: "Invalid tabId" });
       return true;
     }
-    browser.tabs.remove(tabId)
+    browser.tabs
+      .remove(tabId)
       .then(() => {
         sendResponse({ success: true });
       })
       .catch((error) => {
-        console.error("Error closing tab:", error);
+        Logger.error("Error closing tab:", error);
         sendResponse({ error: error.message });
       });
     return true;
@@ -105,8 +107,10 @@ browser.runtime.onMessage.addListener((message, _, sendResponse) => {
         sendResponse(config);
       })
       .catch((error) => {
-        console.error("Error getting config:", error);
+        Logger.error("Error getting config:", error);
       });
     return true;
   }
 });
+
+Logger.log("Background script initialized");

--- a/content.js
+++ b/content.js
@@ -1,5 +1,6 @@
 (async () => {
   const utils = await import(browser.runtime.getURL("utils.js"));
+  const Logger = utils.Logger;
   const keyMatches = utils.keyMatches;
   let configCache = utils.defaultConfig;
 
@@ -77,7 +78,7 @@
    * @returns {Array} - Filtered array of tabs that match the query
    */
   function fuzzyMatch(tabs, query) {
-    console.log(configCache);
+    Logger.log(configCache);
     query = query.toLowerCase();
     tabs = tabs.filter((tab) => {
       const title = getSafeLower(tab.title);
@@ -204,16 +205,16 @@
     /* Explicitly focus the input */
     input.focus();
 
-    /* Handle Escape key globally */
-    const escListener = (e) => {
+    const globalEscListener = (e) => {
       if (keyMatches(e, configCache.keys.closeTabSwitcher)) {
-        closeOmnibar();
         e.preventDefault();
         e.stopPropagation();
+        Logger.info("Close tab switcher key pressed globally");
+        closeOmnibar(e);
       }
     };
 
-    document.addEventListener("keyup", escListener);
+    document.addEventListener("keydown", globalEscListener);
 
     /* Handle tab visibility changes */
     const visibilityListener = () => {
@@ -297,20 +298,20 @@
          */
         function switchToTab(tabId) {
           if (!Number.isInteger(tabId) || tabId < 0) {
-            console.error("Invalid tabId:", tabId);
+            Logger.error("Invalid tabId:", tabId);
             return;
           }
           browser.runtime
             .sendMessage({ type: "switchTab", tabId })
             .then((response) => {
               if (response.error) {
-                console.error("Error response from switchTab:", response.error);
+                Logger.error("Error response from switchTab:", response.error);
                 return;
               }
               closeOmnibar();
             })
             .catch((error) => {
-              console.error("Error sending switchTab message:", error);
+              Logger.error("Error sending switchTab message:", error);
             });
         }
 
@@ -325,13 +326,24 @@
           }
         });
 
-        input.addEventListener("keydown", (e) => {
-          if (keyMatches(e, configCache.keys.closeTabSwitcher)) {
-            // handled by document keyup handler
-            // to ensure it works cross-platform
-            return;
-          }
+        input.addEventListener(
+          "keydown",
+          (e) => {
+            if (keyMatches(e, configCache.keys.closeTabSwitcher)) {
+              e.preventDefault();
+              e.stopPropagation();
+              Logger.info("Close tab switcher key pressed from input");
+              closeOmnibar();
+              return;
+            }
+          },
+          {
+            capture: true,
+            passive: false,
+          },
+        );
 
+        input.addEventListener("keydown", (e) => {
           const items = list.querySelectorAll("li");
           const numItems = items.length;
 
@@ -379,7 +391,7 @@
         }
       })
       .catch((error) => {
-        console.error("Error fetching tabs:", error);
+        Logger.error("Error fetching tabs:", error);
       });
 
     /* Close on click outside */
@@ -395,7 +407,7 @@
       if (overlay) {
         overlay.remove();
         document.removeEventListener("mousemove", mouseMoveListener);
-        document.removeEventListener("keyup", escListener);
+        document.removeEventListener("keydown", globalEscListener);
         document.removeEventListener("visibilitychange", visibilityListener);
         cssOverrides("remove");
       }
@@ -405,12 +417,12 @@
   /* Listen for changes in sync storage */
   browser.storage.onChanged.addListener((changes, areaName) => {
     if (areaName === "sync") {
-      console.log("Sync storage changed:", changes);
+      Logger.log("Sync storage changed:", changes);
       for (const key in changes) {
         const { newValue } = changes[key];
         configCache[key] = newValue;
       }
-      console.log("Config updated in content script:", configCache);
+      Logger.log("Config updated in content script:", configCache);
     }
   });
 
@@ -423,10 +435,10 @@
           configCache.keys[action] = utils.defaultKeys[action];
         }
       }
-      console.log("Initial config loaded in content script:", configCache);
+      Logger.log("Initial config loaded in content script:", configCache);
     })
     .catch((error) => {
-      console.error("Error getting config:", error);
+      Logger.error("Error getting config:", error);
     });
 
   /* Listen for messages from background */

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Zen Browser Tab Switcher",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "Tab switcher for Zen Browser with a minimal omnibar overlay",
   "permissions": [
     "storage",

--- a/options.js
+++ b/options.js
@@ -1,4 +1,4 @@
-import { defaultConfig, defaultConfigKeys } from "./utils.js";
+import { defaultConfig, defaultConfigKeys, Logger } from "./utils.js";
 
 const defaultKeys = defaultConfigKeys;
 let configCache = defaultConfig;
@@ -18,7 +18,7 @@ const saveConfig = async (configObject) => {
   try {
     await browser.storage.sync.set(configObject);
   } catch (error) {
-    console.error("Error saving config:", error);
+    Logger.error("Error saving config:", error);
   }
 };
 
@@ -31,22 +31,23 @@ const loadConfig = async () => {
         configCache.keys[action] = defaultKeys[action];
       }
     }
-    console.log("Loaded config:", configCache);
+    Logger.log("Loaded config:", configCache);
   } catch (error) {
-    console.error("Error loading config:", error);
+    Logger.error("Error loading config:", error);
   }
 };
 
 const updateUI = async () => {
   await loadConfig();
   const commands = await browser.commands.getAll();
-  const toggleCommand = commands.find((c) =>
-    c.name === "show-zen-browner-tab-switcher-omnibar"
+  const toggleCommand = commands.find(
+    (c) => c.name === "show-zen-browner-tab-switcher-omnibar",
   );
 
   if (toggleCommand) {
-    document.querySelector("button[data-action='openTabSwitcher']")
-      .textContent = toggleCommand.shortcut || "None";
+    document.querySelector(
+      "button[data-action='openTabSwitcher']",
+    ).textContent = toggleCommand.shortcut || "None";
   }
 
   for (const action in configCache.keys) {
@@ -80,8 +81,7 @@ const editKey = (evt) => {
     evt.target.dataset.action === "openTabSwitcher"
   ) {
     browser.tabs.create({
-      url:
-        "https://support.mozilla.org/en-US/kb/manage-extension-shortcuts-firefox",
+      url: "https://support.mozilla.org/en-US/kb/manage-extension-shortcuts-firefox",
     });
     return;
   }
@@ -116,9 +116,10 @@ const recordKey = async (evt) => {
 const changePrecedence = async (evt) => {
   const newPrecedence = evt.target.value;
   const validOptions = ["title", "url"];
-  const newValue = newPrecedence === validOptions[0]
-    ? [validOptions[0], validOptions[1]]
-    : [validOptions[1], validOptions[0]];
+  const newValue =
+    newPrecedence === validOptions[0]
+      ? [validOptions[0], validOptions[1]]
+      : [validOptions[1], validOptions[0]];
   configCache.matchPrecedence = newValue;
   await saveConfig(configCache);
 };
@@ -128,7 +129,7 @@ const changeCSSOverrides = async (newCSS) => {
     alert(
       "CSS overrides exceed the maximum allowed size of 50 KB. Changes not saved.",
     );
-    console.error("CSS overrides exceed the maximum allowed size of 50 KB.");
+    Logger.error("CSS overrides exceed the maximum allowed size of 50 KB.");
     return;
   }
   configCache.cssOverrides = newCSS;
@@ -146,12 +147,11 @@ export const debouncedChangeCSSOverrides = (newCSS) => {
   }, 1500);
 };
 
-document.querySelector("textarea[data-type='changeCSS']").addEventListener(
-  "change",
-  (evt) => {
+document
+  .querySelector("textarea[data-type='changeCSS']")
+  .addEventListener("change", (evt) => {
     debouncedChangeCSSOverrides(evt.target.value);
-  },
-);
+  });
 
 document.body.addEventListener("keyup", async (evt) => {
   if (!isRecordingKey) {

--- a/utils.js
+++ b/utils.js
@@ -1,4 +1,7 @@
+export const ADDON_ID = "zen-browser-tab-switcher";
+
 export const cssOverridesId = "zen-browser-tab-switcher-css-overrides";
+
 export const defaultConfigKeys = {
   closeTabSwitcher: { key: "Escape", modifiers: [] },
   nextTab: { key: "ArrowDown", modifiers: [] },
@@ -12,6 +15,30 @@ export const defaultConfig = {
   matchPrecedence: ["title", "url"],
 };
 
+export const Logger = {
+  log: (...args) => {
+    console.log(`[${ADDON_ID}]`, ...args);
+  },
+  error: (...args) => {
+    console.error(`[${ADDON_ID}]`, ...args);
+  },
+  info: (...args) => {
+    console.info(`[${ADDON_ID}]`, ...args);
+  },
+  debug: (...args) => {
+    if (
+      typeof browser !== "undefined" &&
+      browser.runtime &&
+      browser.runtime.getManifest
+    ) {
+      const manifest = browser.runtime.getManifest();
+      if (manifest && manifest.version && manifest.version.includes("dev")) {
+        console.debug(`[${ADDON_ID}]`, ...args);
+      }
+    }
+  },
+};
+
 export const keyMatches = (event, keyConfig) => {
   const { key, modifiers } = keyConfig;
   if (event.key !== key) return false;
@@ -19,28 +46,16 @@ export const keyMatches = (event, keyConfig) => {
   if (modifiers.includes("Alt") && !event.altKey) return false;
   if (modifiers.includes("Shift") && !event.shiftKey) return false;
   if (modifiers.includes("Meta") && !event.metaKey) return false;
-  if (
-    !modifiers.includes("Ctrl") &&
-    event.ctrlKey
-  ) {
+  if (!modifiers.includes("Ctrl") && event.ctrlKey) {
     return false;
   }
-  if (
-    !modifiers.includes("Alt") &&
-    event.altKey
-  ) {
+  if (!modifiers.includes("Alt") && event.altKey) {
     return false;
   }
-  if (
-    !modifiers.includes("Shift") &&
-    event.shiftKey
-  ) {
+  if (!modifiers.includes("Shift") && event.shiftKey) {
     return false;
   }
-  if (
-    !modifiers.includes("Meta") &&
-    event.metaKey
-  ) {
+  if (!modifiers.includes("Meta") && event.metaKey) {
     return false;
   }
   return true;


### PR DESCRIPTION
On KDE Plasma the event still bubbles up and blurs the input, before we can even intercept it.

Hopefully the current approach fixes this.